### PR TITLE
Add support for RDB 13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "redis/7.4.1"]
 	path = redis/7.4.1
 	url = https://github.com/redis/redis.git
+[submodule "redis/8.6.1"]
+	path = redis/8.6.1
+	url = https://github.com/redis/redis.git

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ and ListPack) such that those are only decoded when needed. This allows the
 caller to efficiently skip over these entries or defer their decoding to a
 worker thread.
 
-RDB files created by all versions of Redis through 7.4.x are supported (i.e.,
-RDB versions 1 through 12). Some features, however, are not supported:
+RDB files created by all versions of Redis through 8.x are supported (i.e.,
+RDB versions 1 through 13). Some features, however, are not supported:
 
 - [Modules](https://redis.io/modules), introduced in RDB version 8
 - [Streams](https://redis.io/topics/streams-intro), introduced in RDB version 9.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ End of file. Checksum: 157e40ad49ef13f6
 
 ## References
 
-As of November 2024, the most recent RDB format version is 12. The source of
+As of March 2026, the most recent RDB format version is 13. The source of
 truth is the [rdb.h][] file in the [Redis repo][]. The following resources
 provide a good overview of the RDB format.
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <!-- Sonatype deploy plugin -->

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all
 
 all:
+	$(MAKE) -C 8.6.1
 	$(MAKE) -C 7.4.1
 	$(MAKE) -C 7.2.4
 	$(MAKE) -C 7.0.11

--- a/src/main/java/net/whitbeck/rdbparser/RdbParser.java
+++ b/src/main/java/net/whitbeck/rdbparser/RdbParser.java
@@ -47,6 +47,7 @@ public final class RdbParser implements AutoCloseable {
   private static final int MODULE_AUX = 0xf7;
   private static final int FUNCTION_PRE_GA = 0xf6;
   private static final int FUNCTION2 = 0xf5;
+  private static final int KEY_META = 0xf3;
   private static final int SLOT_INFO = 0xf4;
 
   private static final int BUFFER_SIZE = 8 * 1024;
@@ -160,7 +161,7 @@ public final class RdbParser implements AutoCloseable {
       throw new IllegalStateException("Not a valid redis RDB file");
     }
     version = readVersion();
-    if (version < 1 || version > 12) {
+    if (version < 1 || version > 13) {
       throw new IllegalStateException("Unknown version");
     }
     nextEntry = new KeyValuePair();
@@ -221,6 +222,7 @@ public final class RdbParser implements AutoCloseable {
           readIdle();
           continue;
         case MODULE_AUX:
+        case KEY_META:
           throw new UnsupportedOperationException("Redis modules are not supported");
         case FUNCTION_PRE_GA:
         case FUNCTION2:
@@ -442,6 +444,7 @@ public final class RdbParser implements AutoCloseable {
       case 15: // Stream ListPacks
       case 19: // Stream ListPacks_2
       case 21: // Stream ListPacks_3
+      case 26: // Stream ListPacks_4
         throw new UnsupportedOperationException("Redis streams are not supported");
       case 16:
         readHashListPack();

--- a/src/test/java/net/whitbeck/rdbparser/RdbParserTest.java
+++ b/src/test/java/net/whitbeck/rdbparser/RdbParserTest.java
@@ -93,6 +93,7 @@ public class RdbParserTest {
     new RedisServerInstance("7.0.11", 10),
     new RedisServerInstance("7.2.4", 11),
     new RedisServerInstance("7.4.1", 12),
+    new RedisServerInstance("8.6.1", 13),
   };
 
   @BeforeClass


### PR DESCRIPTION
Adds support for reading RDB 13 files generated by Redis 8.6.*. The majority of the changes to the spec are related to streams and modules which can be ignored for this library.

Java 1.7 is EOL, so I've bumped the version to 1.8 as well.